### PR TITLE
fix UnicodeDecodeError in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ def find_version(*file_paths):
         raise RuntimeError("Unable to find version string.")
 
 
-readme = open('README.rst').read()
-history = open('HISTORY.rst').read().replace('.. :changelog:', '')
+readme = open('README.rst', encoding="utf8").read()
+history = open('HISTORY.rst', encoding="utf8").read().replace('.. :changelog:', '')
 
 requirements = ['six']
 


### PR DESCRIPTION
Windows 10, Anaconda, Polish language version


Fixed this:
```
   ERROR: Command errored out with exit status 1:
     command: 'C:\Users\Matplaneta\anaconda3\python.exe' -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\MATPLA~1\\AppData\\Local\\Temp\\pip-download-5el21o67\\pyeasyga\\setup.py'"'"'; __file__='"'"'C:\\Users\\MATPLA~1\\AppData\\Local\\Temp\\pip-download-5el21o67\\pyeasyga\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base 'C:\Users\MATPLA~1\AppData\Local\Temp\pip-download-5el21o67\pyeasyga\pip-egg-info'
         cwd: C:\Users\MATPLA~1\AppData\Local\Temp\pip-download-5el21o67\pyeasyga\
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\MATPLA~1\AppData\Local\Temp\pip-download-5el21o67\pyeasyga\setup.py", line 30, in <module>
        history = open('HISTORY.rst').read().replace('.. :changelog:', '')
      File "C:\Users\Matplaneta\anaconda3\lib\encodings\cp1250.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 764: character maps to <undefined>
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```